### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/components/home/unravel-section.tsx
+++ b/src/components/home/unravel-section.tsx
@@ -28,7 +28,17 @@ const social_links = [
 
 export function CubingKeralaUnravel() {
   const handleSocialClick = (url: string) => {
-    if (url.includes("whatsapp.com")) {
+    let isWhatsappUrl = false;
+    try {
+      const parsedUrl = new URL(url);
+      const hostname = parsedUrl.hostname.toLowerCase();
+      isWhatsappUrl =
+        hostname === "whatsapp.com" || hostname.endsWith(".whatsapp.com");
+    } catch {
+      isWhatsappUrl = false;
+    }
+
+    if (isWhatsappUrl) {
       if (isMobileDevice()) {
         window.location.assign(url);
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/cubingkeralaorg/cubingkerala/security/code-scanning/1](https://github.com/cubingkeralaorg/cubingkerala/security/code-scanning/1)

Use `URL` parsing and explicit host matching instead of substring matching.

Best fix (without changing intended functionality):
- In `src/components/home/unravel-section.tsx`, inside `handleSocialClick`, parse `url` with `new URL(url)`.
- Normalize the hostname to lowercase.
- Treat only exact WhatsApp domains (e.g. `whatsapp.com` and subdomains like `chat.whatsapp.com`) as WhatsApp links.
- If parsing fails, fall back to the non-WhatsApp behavior (`window.open(url, "_blank")`) to preserve existing UX and avoid runtime crashes.

This requires no new imports or dependencies; `URL` is built-in in browser environments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
